### PR TITLE
Path consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # flit
 
 Experimental tool for understanding and tweaking https://github.com/flutter/ apps
+
+Check this out as a sibling of the flutter checkout folder

--- a/mutation_runner/pubspec.yaml
+++ b/mutation_runner/pubspec.yaml
@@ -6,9 +6,9 @@ dependencies:
   shelf_route: any
   path: any
   flutter_tools:
-    path: ../../GitRepos/flutter/packages/flutter_tools/
+    path: ../../flutter/packages/flutter_tools/
 
   flutter:
-     path: ../../GitRepos/flutter/packages/flutter/
+     path: ../../flutter/packages/flutter/
 
   vm_service_lib: any

--- a/server/pubspec.yaml
+++ b/server/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   shelf_route: any
   path: any
   flutter_tools:
-    path: ../../GitRepos/flutter/packages/flutter_tools
+    path: ../../flutter/packages/flutter_tools
 
   flutter:
-     path: ../../GitRepos/flutter/packages/flutter
+     path: ../../flutter/packages/flutter


### PR DESCRIPTION
@danrubel This makes pubspec consistent with the mutation runner folder structure, and updates the readme with an instruction that flit should be checked out as a sibling to flutter.